### PR TITLE
fix: corrige a lógica do laço de repetição

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -58,7 +58,7 @@ class Troco {
 
         @Override
         public boolean hasNext() {
-            for (int i = 6; i >= 0; i++) {
+            for (int i = troco.papeisMoeda.length-1; i >= 0; i--) {
                 if (troco.papeisMoeda[i] != null) {
                     return true;
                 }


### PR DESCRIPTION
Altera o início do índice para a última posição do vetor de _papeisMoeda_, e decrementa o índice a cada iteração.