### PR TITLE
fix: remove retorno excessivo no método imprime

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/TicketMachine.java
@@ -44,9 +44,7 @@ public class TicketMachine {
         if (saldo < valor) {
             throw new SaldoInsuficienteException();
         }
-        String result = "*****************\n";
-        result += "*** R$ " + saldo + ",00 ****\n";
-        result += "*****************\n";
-        return result;
+        
+        saldo -= valor;
     }
 }


### PR DESCRIPTION
Remove a construção da string e o retorno desnecessário. Adicionalmente também debita o valor do bilhete do saldo atual.