### PR TITLE
fix: corrige a lógica do laço de repetição

### DIFF
--- a/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
+++ b/Source Code Inspection/src/br/calebe/ticketmachine/core/Troco.java
@@ -47,7 +47,7 @@ class Troco {
         @Override
         public PapelMoeda next() {
             PapelMoeda ret = null;
-            for (int i = 6; i >= 0 && ret != null; i++) {
+            for (int i = troco.papeisMoeda.length-1; i >= 0 && ret != null; i--) {
                 if (troco.papeisMoeda[i] != null) {
                     ret = troco.papeisMoeda[i];
                     troco.papeisMoeda[i] = null;


### PR DESCRIPTION
Inicia o índice do laço com o último índice do vetor _papeisMoeda_, e atualiza ação de atualização para decremento.